### PR TITLE
Adding moodle-compose capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ If it is the case, just ensure the projectinfo.yml contains the key: value
 ```
 sqltype: mysql
 ```
+####Note on restoring large mysql dumps
+ It might crash at some for dumps > 2Gb. If it is the case this is the proven manual procedure:
+```
+docker cp [dump.sql] ${MOODLE_CODENAME}_db_1:/var/tmp/[dump.sql] # Not compressed!
+docker exec -it ${MOODLE_CODENAME}_db_1 bash
+mysql -pm@0dl3ing
+SET GLOBAL max_allowed_packet=16*1024*1024;
+quit;
+mysql -pm@0dl3ing
+USE moodle;
+source /var/tmp/[dump.sql]
+quit;
+rm -f /var/tmp/[dump.sql]
+exit
+moodle-compose u
+moodle-compose pc
+```
+*Try at your own risk! :)  Just feel free to try it and share any improvement!*
+
 
 #### If you're setting up the Moodle instance for the first time: 
 
@@ -48,8 +67,11 @@ You should now have a instance available at **https://{codename}.docker.test/**
 Further info in the Readme file of the Moodle directory.
 
 
-#### In addition to all docker-compose commands listed above, you also get:
+#### In addition to all docker-compose and moodle-docker-compose commands, you also get:
 ```bash
+# Quick help
+moodle-compose
+
 # To stop all containers without losing your data
 moodle-compose stop
 
@@ -76,12 +98,11 @@ moodle-compose pgld (moodle-compose pglocaldump)
 
 # To dump a snapshot of the local Mysql DB into [MOODLE_CODENAME]_local_dbdump.sql.gz
 moodle-compose mysqlld (moodle-compose mysqllocaldump)
-
 ```
 
 
 ## Quick start
-
+(Original from moodle-docker-compose)
 ```bash
 # Set up path to Moodle code
 export MOODLE_DOCKER_WWWROOT=/path/to/moodle/code

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ ln -s ~/opt/moodle-docker/bin/moodle-compose ~/.local/bin/
 moodle-compose up -d
 ```
 
+## Working with MYSQL
+If it is the case, just ensure the projectinfo.yml contains the key: value
+```
+sqltype: mysql
+```
+
 #### If you're setting up the Moodle instance for the first time: 
 
 1. Adjust the project info in the Moodle directory by copying the **projectinfo-dist.yml** to **projectinfo.yml** and filling all the client related data.
@@ -62,13 +68,13 @@ moodle-compose at (moodle-compose adhoc_tasks)
 # To restore a Postgres DB dump
 moodle-compose pgr [filename.dbdump] (moodle-compose pgrestore [filename.dbdump])
 
-# To restore a Mysql DB dump (Make sure you are on the moodle-compose's "MYSQL" branch)
+# To restore a Mysql DB dump
 moodle-compose mysqlr [filename.sql.gz] (moodle-compose mysqlrestore [filename.sql.gz])
 
 # To dump a snapshot of the local Postgres DB into [MOODLE_CODENAME]_local_dbdump.pgdump
 moodle-compose pgld (moodle-compose pglocaldump)
 
-# To dump a snapshot of the local Mysql DB nto [MOODLE_CODENAME]_local_dbdump.sql.gz
+# To dump a snapshot of the local Mysql DB into [MOODLE_CODENAME]_local_dbdump.sql.gz
 moodle-compose mysqlld (moodle-compose mysqllocaldump)
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,20 @@ moodle-compose down
 moodle-compose c (moodle-compose cron)
 
 # To run the ad-hoc tasks
-moodle-compose at (moodle-compose adhoc_tasks) 
+moodle-compose at (moodle-compose adhoc_tasks)
 
-# To restore a Postres db dump 
-moodle-compose pgr [filename.dbdump] (moodle-compose pgr [filename.dbdump]) 
+# To restore a Postgres DB dump
+moodle-compose pgr [filename.dbdump] (moodle-compose pgrestore [filename.dbdump])
+
+# To restore a Mysql DB dump (Make sure you are on the moodle-compose's "MYSQL" branch)
+moodle-compose mysqlr [filename.sql.gz] (moodle-compose mysqlrestore [filename.sql.gz])
+
+# To dump a snapshot of the local Postgres DB into [MOODLE_CODENAME]_local_dbdump.pgdump
+moodle-compose pgld (moodle-compose pglocaldump)
+
+# To dump a snapshot of the local Mysql DB nto [MOODLE_CODENAME]_local_dbdump.sql.gz
+moodle-compose mysqlld (moodle-compose mysqllocaldump)
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ moodle-compose c (moodle-compose cron)
 
 # To run the ad-hoc tasks
 moodle-compose at (moodle-compose adhoc_tasks) 
+
+# To restore a Postres db dump 
+moodle-compose pgr [filename.dbdump] (moodle-compose pgr [filename.dbdump]) 
 ```
 
 

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -61,6 +61,7 @@ if ! [ -r ./config.php ] || ! diff -q $MOODLE_DOCKER_DIR/config.docker-template.
 fi
 
 ARGS=
+dump=
 
 if [ -n "$1" ]; then
     case $1 in
@@ -92,7 +93,36 @@ if [ -n "$1" ]; then
         ARGS="exec webserver php admin/cli/cron.php"
         shift 1
         ;;
+    pgrestore|pgr)
+        if [ -z $2  ]; then
+	        echo "Insert the name of the pgdump file: "
+	        read dump
+        else
+	        dump=$2
+        fi
+        clear
+        printf "\n>>> Copying the pgdump file to the ${MOODLE_CODENAME}_db_1  volume\n------------------------------------------------------\n"
+        # It depends on Python, but who does not have it this days?
+        destination_folder=$(docker inspect -f '{{ json .Mounts }}' ${MOODLE_CODENAME}_db_1 | python -m json.tool | grep Destination | cut -d':' -f2 | cut -d'"' -f2)
+        date=$(date +%Y%m%d)
+        filename=${destination_folder}/${MOODLE_CODENAME}.${date}.${dump}
+        printf "${filename}\n"
+        docker cp ${dump} ${MOODLE_CODENAME}_db_1:${filename}
+        printf "\n>>> Removing the moodle DB\n--------------------------\n"
+        docker exec -t ${MOODLE_CODENAME}_db_1 /usr/bin/dropdb -e -U moodle moodle
+        printf "\n>>> Recreating the DB moodle from template0\n-------------------------------------------\n"
+        docker exec -t ${MOODLE_CODENAME}_db_1 /usr/bin/createdb -e -U moodle --template=template0 --owner=moodle moodle
+        printf "\n>>> Restoring the moodle DB with the pgdump file (Chill for a while)\n--------------------------------------------------------------------\n"
+        docker exec ${MOODLE_CODENAME}_db_1 /usr/bin/pg_restore -U moodle -d moodle --no-owner ${filename} && echo ""
+        printf "\n>>> DB restored! Removing the pgdump file...\n"
+        docker exec ${MOODLE_CODENAME}_db_1 rm ${filename}
+        printf "\n>>> Updating moodle DB\n----------------------\n"
+        moodle-compose u
+        printf "\n>>> Purging the Moodle cache\n----------------------------\n"
+        moodle-compose pc
+        printf "\nMoodle is ready => http://${MOODLE_CODENAME}.docker.test\n"
+        exit 1
+        ;;
     esac
 fi
-
 $MOODLE_DOCKER_DIR/bin/moodle-docker-compose $ARGS "$@"

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -100,6 +100,10 @@ if [ -n "$1" ]; then
         else
 	        dump=$2
         fi
+        if [ ! -f $dump ]; then
+          >&2  printf "\n>> File $dump not found\n\n"
+          exit 1
+        fi
         clear
         printf "\n>>> Removing the Moodle DB\n\n"
         moodle-compose exec -T db /usr/bin/dropdb -e -U moodle moodle

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -101,24 +101,15 @@ if [ -n "$1" ]; then
 	        dump=$2
         fi
         clear
-        printf "\n>>> Copying the pgdump file to the ${MOODLE_CODENAME}_db_1  volume\n------------------------------------------------------\n"
-        # It depends on Python, but who does not have it this days?
-        destination_folder=$(docker inspect -f '{{ json .Mounts }}' ${MOODLE_CODENAME}_db_1 | python -m json.tool | grep Destination | cut -d':' -f2 | cut -d'"' -f2)
-        date=$(date +%Y%m%d)
-        filename=${destination_folder}/${MOODLE_CODENAME}.${date}.${dump}
-        printf "${filename}\n"
-        docker cp ${dump} ${MOODLE_CODENAME}_db_1:${filename}
-        printf "\n>>> Removing the moodle DB\n--------------------------\n"
-        docker exec -t ${MOODLE_CODENAME}_db_1 /usr/bin/dropdb -e -U moodle moodle
-        printf "\n>>> Recreating the DB moodle from template0\n-------------------------------------------\n"
-        docker exec -t ${MOODLE_CODENAME}_db_1 /usr/bin/createdb -e -U moodle --template=template0 --owner=moodle moodle
-        printf "\n>>> Restoring the moodle DB with the pgdump file (Chill for a while)\n--------------------------------------------------------------------\n"
-        docker exec ${MOODLE_CODENAME}_db_1 /usr/bin/pg_restore -U moodle -d moodle --no-owner ${filename} && echo ""
-        printf "\n>>> DB restored! Removing the pgdump file...\n"
-        docker exec ${MOODLE_CODENAME}_db_1 rm ${filename}
-        printf "\n>>> Updating moodle DB\n----------------------\n"
+        printf "\n>>> Removing the Moodle DB\n\n"
+        moodle-compose exec -T db /usr/bin/dropdb -e -U moodle moodle
+        printf "\n>>> Recreating the Moodle DB from template0\n\n"
+        moodle-compose exec -T db /usr/bin/createdb -e -U moodle -T template0 -O moodle moodle
+        printf "\n>>> Restoring the Moodle DB with the pgdump file (Chill for a while)\n\n"
+        cat $dump | moodle-compose exec -T db /usr/bin/pg_restore -U moodle -d moodle --no-owner && echo ""
+        printf "\n>>> Moodle DB restored!\n\n>>> Updating Moodle DB\n\n"
         moodle-compose u
-        printf "\n>>> Purging the Moodle cache\n----------------------------\n"
+        printf "\n>>> Purging the Moodle cache\n\n"
         moodle-compose pc
         printf "\nMoodle is ready => http://${MOODLE_CODENAME}.docker.test\n"
         exit 1

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -136,16 +136,16 @@ if [ -n "$1" ]; then
     mysqlrestore|mysqlr)
         #  Note: Restoring large mysql dumps might crash at some point (e.g EPFL: ~4Gb)
         #  If it is the case this is the proven manual procedure:
-        #     docker cp [dump.sql] mdl-epfl_db_1:/var/lib/mysql/[dump.sql] # Not compressed!
+        #     docker cp [dump.sql] ${MOODLE_CODENAME}_db_1:/var/tmp/[dump.sql] # Not compressed!
         #     docker exec -it ${MOODLE_CODENAME}_db_1 bash
         #     mysql -pm@0dl3ing
         #     SET GLOBAL max_allowed_packet=16*1024*1024;
         #     quit;
         #     mysql -pm@0dl3ing
         #     USE moodle;
-        #     source /var/lib/mysql/[dump.sql]
+        #     source /var/tmp/[dump.sql]
         #     quit;
-        #     rm -f /var/lib/mysql/[dump.sql]
+        #     rm -f /var/tmp/[dump.sql]
         #     exit
         #     moodle-compose u
         #     moodle-compose pc
@@ -199,6 +199,8 @@ else
     mysqlrestore|mysqlr     Restore MYSQL Moodle DB from .sql.gz file
     mysqllocaldump|mysqlld  Dump the local MYSQL Moodle DB to [MOODLE_CODENAME]_local_dbdump.sql.gz
 
+    Also, all docker-compose commands will work as well, for instance:
+        moodle-compose exec webserver bash
     "
   exit 1
 fi

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -118,6 +118,83 @@ if [ -n "$1" ]; then
         printf "\nMoodle is ready => http://${MOODLE_CODENAME}.docker.test\n"
         exit 1
         ;;
+
+    pglocaldump|pgld)
+        # Useful to have a local snapshot of DB after some work (specially upgrading the db, which could be time burner)
+        filename="${MOODLE_CODENAME}_local_dbdump.pgdump"
+        moodle-compose exec -T db /usr/bin/pg_dump -U moodle --format=custom -f ${filename} moodle
+        printf "\nMoodle local DB has been dumped => ${filename}"
+        exit 1
+        ;;
+
+    mysqlrestore|mysqlr)
+        #  Note: Restoring large mysql dumps might crash at some point (e.g EPFL: ~4Gb)
+        #  If it is the case this is the proven manual procedure:
+        #     docker cp [dump.sql] mdl-epfl_db_1:/var/lib/mysql/[dump.sql] # Not compressed!
+        #     docker exec -it ${MOODLE_CODENAME}_db_1 bash
+        #     mysql -pm@0dl3ing
+        #     SET GLOBAL max_allowed_packet=16*1024*1024;
+        #     quit;
+        #     mysql -pm@0dl3ing
+        #     USE moodle;
+        #     source /var/lib/mysql/[dump.sql]
+        #     quit;
+        #     rm -f /var/lib/mysql/[dump.sql]
+        #     exit
+        #     moodle-compose u
+        #     moodle-compose pc
+        #
+        #                            Try at your own risk! Feel free to improve it!
+
+        if [ -z $2  ]; then
+            echo "Insert the name of the mysql dump file (.sql.gz) "
+            read dump
+            else
+            dump=$2
+        fi
+        if [ ! -f $dump ]; then
+            >&2  printf "\n>> File $dump not found\n\n"
+            exit 1
+        fi
+        clear
+        printf "\n>>> Restoring the Moodle DB with the dbdump file (Chill for a while)\n\n"
+        gunzip < $dump | moodle-compose exec -T db /usr/bin/mysql -u root --show-warnings --password=m@0dl3ing moodle
+        printf "\n>>> Moodle DB restored!\n\n>>> Updating Moodle DB\n\n"
+        moodle-compose u
+        printf "\n>>> Purging the Moodle cache\n\n"
+        moodle-compose pc
+        printf "\nMoodle is ready => http://${MOODLE_CODENAME}.docker.test\n"
+        exit 1
+        ;;
+
+    mysqllocaldump|mysqlld)
+        # Useful to have a local snapshot of DB after some work (specially upgrading the db, which could be time burner)
+        clear
+        printf "\n>>> Dumping the local Moodle mysql DB (Chill for a while)\n\n"
+        moodle-compose exec -T db /usr/bin/mysqldump -u root --password=m@0dl3ing moodle | gzip > ${MOODLE_CODENAME}_local_dbdump.sql.gz
+        printf "\nThe local Moodle DB has been dumped to the file => ${MOODLE_CODENAME}_local_dbdump.sql.gz\n"
+        exit 1
+        ;;
+
     esac
+else
+    echo "
+    moodle-compose is a Liip implementation based on moodle-docker-compose
+
+    Usage (at least one option should be provided)
+
+    install|i               Moodle installation
+    upgrade|u               Moodle DB uprade
+    purge_caches|pc         Moddle cache purge
+    adhoc_tasks|at          Process Moodle adhoc_tasks
+    cron|c                  Process all pending Moodle Cron Jobs
+    pgrestore|pgr           Restore POSTGRES Moodle DB from .pgdump file
+    pglocaldump|pgld        Dump the local Postgres Moodle DB to [MOODLE_CODENAME]_local_dbdump.pgdump
+    mysqlrestore|mysqlr     Restore MYSQL Moodle DB from .sql.gz file
+    mysqllocaldump|mysqlld  Dump the local MYSQL Moodle DB to [MOODLE_CODENAME]_local_dbdump.sql.gz
+
+    "
+  exit 1
 fi
+
 $MOODLE_DOCKER_DIR/bin/moodle-docker-compose $ARGS "$@"

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -128,13 +128,13 @@ if [ -n "$1" ]; then
     pglocaldump|pgld)
         # Useful to have a local snapshot of DB after some work (specially upgrading the db, which could be time burner)
         filename="${MOODLE_CODENAME}_local_dbdump.pgdump"
-        moodle-compose exec -T db /usr/bin/pg_dump -U moodle --format=custom -f ${filename} moodle
+        moodle-compose exec -T db /usr/bin/pg_dump -U moodle --format=custom moodle > ${filename}
         printf "\nMoodle local DB has been dumped => ${filename}"
         exit 1
         ;;
 
     mysqlrestore|mysqlr)
-        #  Note: Restoring large mysql dumps might crash at some point (e.g EPFL: ~4Gb)
+        #  Note: Restoring large mysql dumps might crash at some point (e.g ~4Gb)
         #  If it is the case this is the proven manual procedure:
         #     docker cp [dump.sql] ${MOODLE_CODENAME}_db_1:/var/tmp/[dump.sql] # Not compressed!
         #     docker exec -it ${MOODLE_CODENAME}_db_1 bash

--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -30,6 +30,7 @@ fi
 # Moodle instance settings
 if [ -r "$MOODLE_DOCKER_WWWROOT/projectinfo.yml" ]; then
     MOODLE_CODENAME=$(grep -e  '^codename' "$MOODLE_DOCKER_WWWROOT/projectinfo.yml" | awk -F ': ' '{print $2}')
+    MOODLE_DB_TYPE=$(grep -e  '^sqltype' "$MOODLE_DOCKER_WWWROOT/projectinfo.yml" | awk -F ': ' '{print $2}')
 fi
 
 if [ -z "${MOODLE_CODENAME}" ]; then
@@ -43,7 +44,12 @@ fi
 export MOODLE_CODENAME=${MOODLE_CODENAME}
 
 # Related to Moodle
-export MOODLE_DOCKER_DB=${MOODLE_DOCKER_DB:-pgsql}
+if [ -z "${MOODLE_DB_TYPE}" ]; then
+    export MOODLE_DOCKER_DB=${MOODLE_DOCKER_DB:-pgsql}
+else
+    export MOODLE_DOCKER_DB=${MOODLE_DOCKER_DB:-${MOODLE_DB_TYPE}}
+fi
+
 export MOODLE_DOCKER_PHP_VERSION=${MOODLE_DOCKER_PHP_VERSION:-7.2}
 
 # Related to one's local setup


### PR DESCRIPTION
Hello, I added the following capabilities, also a message is shown if no option is given to the **moodle-compose** command.

- To restore a Mysql DB dump 
`moodle-compose mysqlr [filename.sql.gz] (moodle-compose mysqlrestore [filename.sql.gz])`

- To dump a snapshot of the local Postgres DB into [MOODLE_CODENAME]_local_dbdump.pgdump
`moodle-compose pgld (moodle-compose pglocaldump)`

- To dump a snapshot of the local Mysql DB into [MOODLE_CODENAME]_local_dbdump.sql.gz
`moodle-compose mysqlld (moodle-compose mysqllocaldump)`