### PR TITLE
fix script to works without traefik as well

### DIFF
--- a/bin/moodle-compose
+++ b/bin/moodle-compose
@@ -66,6 +66,13 @@ if ! [ -r ./config.php ] || ! diff -q $MOODLE_DOCKER_DIR/config.docker-template.
     cp $MOODLE_DOCKER_DIR/config.docker-template.php ./config.php
 fi
 
+ADMINEMAIL="admin@${MOODLE_DOCKER_WEB_HOST}"
+# In case the web host isn't a valid domain
+if [[ "${MOODLE_DOCKER_WEB_HOST}" != *"."* ]]
+then
+  ADMINEMAIL="admin@${MOODLE_DOCKER_WEB_HOST}.test"
+fi
+
 ARGS=
 dump=
 
@@ -77,7 +84,7 @@ if [ -n "$1" ]; then
         ARGS="$ARGS --agree-license"
         ARGS="$ARGS --fullname=${MOODLE_CODENAME}"
         ARGS="$ARGS --shortname=${MOODLE_CODENAME}"
-        ARGS="$ARGS --adminemail=admin@${MOODLE_DOCKER_WEB_HOST}"
+        ARGS="$ARGS --adminemail=${ADMINEMAIL}"
         ARGS="$ARGS --adminuser=admin"
         ARGS="$ARGS --adminpass=adminadmin"
         shift 1

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -170,7 +170,8 @@ export MOODLE_DOCKER_WEB_HOST=${MOODLE_DOCKER_WEB_HOST:-localhost}
 
 # Webserver port
 export MOODLE_DOCKER_WEB_PORT=${MOODLE_DOCKER_WEB_PORT:-8000}
-if [[ $MOODLE_DOCKER_WEB_PORT == *":"* ]] || [[ $MOODLE_DOCKER_WEB_PORT -gt 0 ]] && [ -z "$MOODLE_DOCKER_TRAEFIK" ]
+
+if [[ $MOODLE_DOCKER_WEB_PORT == *":"* ]] || [[ $MOODLE_DOCKER_WEB_PORT -gt 0 ]] && [ "$MOODLE_DOCKER_TRAEFIK" != "enable" ]
 then
     # If no bind ip has been configured (bind_ip:port), default to 127.0.0.1
     if [[ ! $MOODLE_DOCKER_WEB_PORT == *":"* ]]


### PR DESCRIPTION
Moodle-docker didn't work without traefik because:
1. The admin email use the hostname for the mail domain and @localhost is not a valid domain
2. MOODLE_DOCKER_TRAEFIK lenght string was never zero